### PR TITLE
Fixed Eventbrite fetch so address now displays instead of undefined

### DIFF
--- a/src/scripts/data.js
+++ b/src/scripts/data.js
@@ -55,9 +55,9 @@ const data = {
     },
 
     queryEvents() {
-        fetch("https://www.eventbriteapi.com/v3/events/search/?location.latitude=36.174465&location.longitude=-86.767960&token=BJXHAMMBOWECTXM2ZLAL", {
+        fetch("https://www.eventbriteapi.com/v3/events/search/?location.latitude=36.174465&location.longitude=-86.767960&token=BJ2CF2XZDBK773VFPGPW", {
             headers: {
-                "Authorization": "Bearer BJXHAMMBOWECTXM2ZLAL"
+                "Authorization": "Bearer BJ2CF2XZDBK773VFPGPW"
             }
         })
             .then(response => response.json())
@@ -75,8 +75,8 @@ const data = {
                         .then(venues => venues.json())
                         .then(parsedVenues => {
                             
-                            let venueAddress = parsedVenues.name.address_1;
-                            console.log(`Venue Name: ${venueName} Venue Address: ${venueAddress}`);
+                            let venueAddress = parsedVenues.address.address_1;
+                            console.log(`Event: ${venueName} Address: ${venueAddress}`);
 
                             // let eventHTML = event.name
                             // let two = "test"


### PR DESCRIPTION
# Description
Fixed Eventbrite fetch so address now displays instead of "undefined"

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions for Change Made
1. `git fetch --all`
2. `git checkout meg-eventbrite-fetch`
3. Run server/grunt
4. Verify that address displays when you click the "Lets Go" button under Meetups.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works