### PR TITLE
Rewrote code so that the internal value of each option is passed

### DIFF
--- a/src/scripts/domBuilder.js
+++ b/src/scripts/domBuilder.js
@@ -6,20 +6,25 @@ const domBuilder = {
 
         <select name="parkSearch" id="parkSearch">
             <option value="" selected disabled hidden>Parks by feature</option>
-            <option>ADA Accessible</option>
-            <option>Baseball Fields</option>
-            <option>Boat Launch</option>
-            <option>Community Center</option>
-            <option>Disc Golf</option>
-            <option>Dog Park</option>
-            <option>Hiking Trails</option>
-            <option>Horse Trails</option>
-            <option>Lake</option>
-            <option>Playground</option>
-            <option>Restrooms Available</option>
-            <option>Skate Park</option>
-            <option>Swimming Pool</option>
-            <option>Tennis Courts</option>
+            <option value="ada_accessible">ADA Accessible</option>
+            <option value="baseball_fields">Baseball Fields</option>
+            <option value="basketball_courts">Basketball Courts</option>
+            <option value="boat_launch">Boat Launch</option>
+            <option value="community_center">Community Center</option>
+            <option value="disc_golf">Disc Golf</option>
+            <option value="dog_park">Dog Park</option>
+            <option value="fishing_by_permit">Fishing</option>
+            <option value="football_multi_purpose_fields">Football Fields</option>
+            <option value="hiking_trails">Hiking Trails</option>
+            <option value="horse_trails">Horse Trails</option>
+            <option value="lake">Lake</option>
+            <option value="playground">Playground</option>
+            <option value="restrooms_available">Restrooms Available</option>
+            <option value="skate_park">Skate Park</option>
+            <option value="soccer_fields">Soccer Fields</option>
+            <option value="swimming_pool">Swimming Pool</option>
+            <option value="tennis_courts">Tennis Courts</option>
+            <option value="walk_jog_paths">Walking/Jogging Paths</options>
         </select>
         <br>
         <button type="button" id="parksButton">LETS GO!</button>


### PR DESCRIPTION
# Description
Rewrote code so that the internal value of each option in the Parks drop down is passed instead of the printed value. (i.e. added value="" to each option)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions for Change Made
1. `git fetch --all`
2. `git checkout meg-parks-feature-test`
3. Run server/grunt
4. Verify that all the features in the Parks drop down populate results. Specific ones to look at are Fishing, Football Fields, and Walk/Jog Path. 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works