### PR TITLE
Fixed BR tag display in Itinerary container

### DIFF
--- a/src/scripts/domBuilder.js
+++ b/src/scripts/domBuilder.js
@@ -52,10 +52,13 @@ const domBuilder = {
         let resultsField =
         `
         <div>
-         <p>
-         ${Title}<br>
-         ${extraInfo}</p>
-         <button type = button class ="saveButton ${resultType}">Save</button>
+            <div>
+                <p>
+                ${Title}
+                <br />
+                ${extraInfo}</p>
+            </div>
+            <button type="button" class="saveButton ${resultType}">Save</button>
          </div>
          `
 

--- a/src/scripts/eventListener.js
+++ b/src/scripts/eventListener.js
@@ -71,12 +71,11 @@ function restaurantsValue() {
 
 let notAnonymous = (event) => {
    
-   let clickedButton = event.target.parentElement.firstElementChild.textContent;;
+   let clickedButton = event.target.parentElement.firstElementChild.innerHTML;
    let buttonClass = event.target.classList[1];
    
-
-  console.log(clickedButton, buttonClass);
-domBuilder.itineraryBuilder(clickedButton, buttonClass);
+   console.log(clickedButton, buttonClass);
+   domBuilder.itineraryBuilder(clickedButton, buttonClass);
 }
 
 let clickSave = () => {


### PR DESCRIPTION
# Description
Updated `notAnonymous()` and `resultsBuilder()` to use `innerHTML` instead of `textContent` so that `<br>` would be passed to the itinerary container.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions for Change Made
1. `git fetch --all`
2. `git checkout meg-adding-br-to-itinerary`
3. Run server/grunt
4. Verify that the break tag is now working when you save to the itinerary container, so that the address/date now displays below the event/park/restaurant name.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works